### PR TITLE
LLVM class exam solution - Vlastimil Dort

### DIFF
--- a/compiler.cpp
+++ b/compiler.cpp
@@ -390,6 +390,9 @@ public:
             case ast::BinExp::Type::gt:
                 result = RUNTIME_CALL(genericGt, lhs, rhs);
                 return;
+            case ast::BinExp::Type::dot:
+                result = RUNTIME_CALL(genericDot, lhs, rhs);
+                return;
             default: // can't happen
                 return;
         }

--- a/runtime.cpp
+++ b/runtime.cpp
@@ -526,11 +526,19 @@ RVal * c(int size, ...) {
 }
 
 double doubleDot(DoubleVector * lhs, DoubleVector * rhs) {
-    assert(false and "Fill me in");
+    int productSize = max(lhs->size, rhs->size);
+    double result = 0;
+    for (int i = 0; i < productSize; ++i)
+        result += lhs->data[i % lhs->size] * rhs->data[i % rhs->size];
+    return result;
 }
 
 RVal * genericDot(RVal * lhs, RVal * rhs) {
-    assert(false and "Fill me in");
+    if (lhs->type != rhs->type)
+        throw "Incompatible types for dot product operator";
+    if (lhs->type != RVal::Type::Double)
+        throw "Invalid types for dot product operator";
+    return new RVal(new DoubleVector(doubleDot(lhs->d, rhs->d)));
 }
 
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -226,7 +226,7 @@ namespace rift {
         project3();
         project4();
         project5();
-        // project6();
+        project6();
     }
 
 } // namespace rift

--- a/tests.cpp
+++ b/tests.cpp
@@ -225,7 +225,7 @@ namespace rift {
         project2();
         project3();
         project4();
-        // project5();
+        project5();
         // project6();
     }
 

--- a/tests.cpp
+++ b/tests.cpp
@@ -224,7 +224,7 @@ namespace rift {
 
         project2();
         project3();
-        // project4();
+        project4();
         // project5();
         // project6();
     }

--- a/tests.cpp
+++ b/tests.cpp
@@ -222,7 +222,7 @@ namespace rift {
         TEST("a = \"aba\" a[c(0,2)]", "aa");
         TEST("a = c(1,2,3) a[c(0,1)] = 56 a", 56, 56, 3);
 
-        // project2();
+        project2();
         // project3();
         // project4();
         // project5();

--- a/tests.cpp
+++ b/tests.cpp
@@ -223,7 +223,7 @@ namespace rift {
         TEST("a = c(1,2,3) a[c(0,1)] = 56 a", 56, 56, 3);
 
         project2();
-        // project3();
+        project3();
         // project4();
         // project5();
         // project6();

--- a/type_analysis.cpp
+++ b/type_analysis.cpp
@@ -14,7 +14,10 @@ char TypeAnalysis::ID = 0;
 
 AType * AType::top = createTop();
 
-
+void TypeAnalysis::genericDot(CallInst * ci) {
+    // The result of the %*% operator is (if it succeeds) always a single scalar
+    state.update(ci, new AType(AType::Kind::R, AType::Kind::DV, AType::Kind::D));
+}
 
 void TypeAnalysis::genericArithmetic(CallInst * ci) {
     AType * lhs = state.get(ci->getOperand(0));
@@ -100,6 +103,8 @@ bool TypeAnalysis::runOnFunction(llvm::Function & f) {
                         genericArithmetic(ci);
                     } else if (s == "genericDiv") {
                         genericArithmetic(ci);
+                    } else if (s == "genericDot") {
+                        genericDot(ci);
                     } else if (s == "genericEq") {
                         genericRelational(ci);
                     } else if (s == "genericNeq") {

--- a/type_analysis.h
+++ b/type_analysis.h
@@ -218,6 +218,7 @@ public:
 
 private:
     void genericArithmetic(llvm::CallInst * ci);
+    void genericDot(llvm::CallInst * ci);
     void genericRelational(llvm::CallInst * ci);
     void genericGetElement(llvm::CallInst * ci);
 

--- a/unboxing.h
+++ b/unboxing.h
@@ -48,6 +48,8 @@ protected:
 
     bool genericAdd();
 
+    bool genericDot();
+
     bool genericArithmetic(llvm::Instruction::BinaryOps op, llvm::Function * fop);
 
     void doubleRelational(AType * lhs, AType * rhs, llvm::CmpInst::Predicate op, llvm::Function * fop);


### PR DESCRIPTION
Student CŽV

The genericDot always returns a single double.
The analysis could be a bit more precise if bottom
was returned when the call is guaranteed to fail.
However, genericArithmetic and genericRelational
do not do this.
